### PR TITLE
ci: update Fedora 40 and Fedora Rawhide GCP image upload tasks

### DIFF
--- a/tools/startup-script.sh
+++ b/tools/startup-script.sh
@@ -6,7 +6,11 @@ source /etc/os-release
 
 # All Fedora GCP images do not support auto resize root disk
 if [[ "$ID" == "fedora" ]]; then
-    growpart /dev/sda 5
+    if [[ "$VERSION_ID" == "40" || "$VERSION_ID" == "41"  ]]; then
+        growpart /dev/sda 4
+    else
+        growpart /dev/sda 5
+    fi
     btrfs filesystem resize 1:+70G /
     dnf install -y python3 python3-dnf
 fi

--- a/tools/upload_gcp_image.yml
+++ b/tools/upload_gcp_image.yml
@@ -8,21 +8,24 @@
     gcp_service_account_name: "{{ lookup('env', 'GCP_SERVICE_ACCOUNT_NAME') }}"
     gcp_project: "{{ lookup('env', 'GCP_PROJECT') }}"
     os: "fedora-rawhide"
+    ref_disk_size: 70
     image_url:
       fedora-rawhide: https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Cloud/x86_64/images
-      fedora-39: https://dl.fedoraproject.org/pub/fedora/linux/development/39/Cloud/x86_64/images
+      fedora-40: https://dl.fedoraproject.org/pub/fedora/linux/development/40/Cloud/x86_64/images
+      fedora-39: https://dl.fedoraproject.org/pub/fedora/linux/releases/39/Cloud/x86_64/images
       fedora-38: https://dl.fedoraproject.org/pub/fedora/linux/releases/38/Cloud/x86_64/images
       fedora-37: https://dl.fedoraproject.org/pub/fedora/linux/releases/37/Cloud/x86_64/images
     # image name must be a match of regex '[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?|[1-9][0-9]{0,19}'
     gcp_image_name:
       fedora-rawhide: "kite-image-fedora-rawhide"
+      fedora-40: "kite-image-fedora-40"
       fedora-39: "kite-image-fedora-39"
       fedora-38: "kite-image-fedora-38"
       fedora-37: "kite-image-fedora-37"
 
   tasks:
     - name: get latest Fedora rawhide images
-      shell: curl -s {{ image_url[os] }}/ | grep -ioE '>Fedora-Cloud-Base-GCP-Rawhide-.*.x86_64.tar.gz<' | tr -d '><'
+      shell: curl -s {{ image_url[os] }}/ | grep -ioE '>Fedora-Cloud-Base-GCE.x86_64-Rawhide-.*.tar.gz<' | tr -d '><'
       register: result_file
       when: os == "fedora-rawhide"
 
@@ -30,6 +33,17 @@
         image_file_name: "{{ result_file.stdout }}"
       when:
         - os == "fedora-rawhide"
+        - result_file.changed
+
+    - name: get latest Fedora 40 images
+      shell: curl -s {{ image_url[os] }}/ | grep -ioE '>Fedora-Cloud-Base-GCE.x86_64-40.*.tar.gz<' | tr -d '><'
+      register: result_file
+      when: os == "fedora-40"
+
+    - set_fact:
+        image_file_name: "{{ result_file.stdout }}"
+      when:
+        - os == "fedora-40"
         - result_file.changed
 
     - name: get latest Fedora 39 images
@@ -155,7 +169,7 @@
           fail:
             msg: "can't find disk growpart support, edge image {{ os }} fail"
           when:
-            - "'79G' not in result_growpart.stdout"
+            - "result_growpart.stdout | regex_search('/dev/sda[0-9]\\s+\\d+G') | regex_search('(\\d+)G') | regex_search('\\d+') | int < ref_disk_size"
 
       rescue:
         - name: "delete {{ image_file_name }} from bucket {{ gcp_storage_bucket_name }}"


### PR DESCRIPTION
Fedora 40 and Fedora Rawhide are using device sda4 (previous versions have been using sda5).

The images (F40 and Rawhide) have changed their name from GCP to GCE (GCP Compute Engine).

The playbook task that checks the disk growpart feature has been also updated. This task will fail if the disk partition don't grow up to at least 70G.